### PR TITLE
Fixed warning for when exception variable was not used

### DIFF
--- a/src/FoodTruckNation.Core/AppServices/FoodTruckService.cs
+++ b/src/FoodTruckNation.Core/AppServices/FoodTruckService.cs
@@ -142,7 +142,7 @@ namespace FoodTruckNation.Core.AppServices
 
                 return Result.Success<FoodTruck>(foodTruck);
             }
-            catch (DBConcurrencyException ce)
+            catch (DBConcurrencyException)
             {
                 // If there is a database conflict, then data access layer (like EF) will throw a DbConcurrencyException, so we catch it and turn
                 // it into an error to be passed up the stack with the existing object


### PR DESCRIPTION
In this case, we just need to know that a DbConcurrencyException was thrown, don't need the variable, so cleaned up that warning